### PR TITLE
fix: use major of semantic-release extra plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,6 @@ jobs:
             ]
           extra_plugins: |
             @semantic-release/github
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Seems like there is a bug with semantic-release plugins conflicting with latest major conventional commits. Reverting as issue suggests: https://github.com/semantic-release/release-notes-generator/issues/633